### PR TITLE
feat: add smart PDB configuration switching with automatic defaults

### DIFF
--- a/helm/castai-pdb-controller/README.md
+++ b/helm/castai-pdb-controller/README.md
@@ -63,7 +63,7 @@ helm install castai-pdb-controller castai/castai-pdb-controller \
 | `serviceAccount.name` | Service account name | `"castai-pdb-controller"` |
 | `serviceAccount.annotations` | Service account annotations | `{}` |
 | `rbac.create` | Create RBAC resources | `true` |
-| `config.defaultMinAvailable` | Default minAvailable for PDBs | `null` (unset) |
+| `config.defaultMinAvailable` | Default minAvailable for PDBs | `"1"` (automatic PDB creation) |
 | `config.defaultMaxUnavailable` | Default maxUnavailable for PDBs | `null` (unset) |
 | `config.FixPoorPDBs` | Automatically fix poor PDB configurations | `"false"` |
 | `config.logInterval` | Log interval for repeated messages | `"15m"` |
@@ -85,7 +85,7 @@ helm install castai-pdb-controller castai/castai-pdb-controller \
 
 ### PDB Configuration
 
-The controller supports two PDB configuration modes. By default, neither is set, giving you full flexibility to choose your preferred mode.
+The controller supports two PDB configuration modes. By default, `minAvailable: "1"` is enabled for automatic PDB creation.
 
 #### MinAvailable Mode
 ```yaml
@@ -110,7 +110,7 @@ config:
   defaultMaxUnavailable: null  # or "" or omit entirely
 ```
 
-**Note**: Use either `defaultMinAvailable` or `defaultMaxUnavailable`, not both. If both are set, the controller will log an error and ignore both values.
+**Note**: Use either `defaultMinAvailable` or `defaultMaxUnavailable`, not both. If both are set, `defaultMinAvailable` takes precedence. The template ensures only one value is present in the ConfigMap.
 
 ### Using Helm --set Flag
 
@@ -127,16 +127,8 @@ helm install castai-pdb-controller castai/castai-pdb-controller \
   --set config.defaultMaxUnavailable="50%" \
   -n castai-agent --create-namespace
 
-# Unset minAvailable (use maxUnavailable instead)
+# Use defaults (minAvailable: "1" - automatic PDB creation)
 helm install castai-pdb-controller castai/castai-pdb-controller \
-  --set config.defaultMinAvailable=null \
-  --set config.defaultMaxUnavailable="25%" \
-  -n castai-agent --create-namespace
-
-# Disable default PDB configuration entirely
-helm install castai-pdb-controller castai/castai-pdb-controller \
-  --set config.defaultMinAvailable=null \
-  --set config.defaultMaxUnavailable=null \
   -n castai-agent --create-namespace
 ```
 

--- a/helm/castai-pdb-controller/templates/configmap.yaml
+++ b/helm/castai-pdb-controller/templates/configmap.yaml
@@ -6,17 +6,14 @@ metadata:
   labels:
     {{- include "castai-pdb-controller.labels" . | nindent 4 }}
 data:
-  {{- if .Values.config.defaultMinAvailable }}
   {{- $minAvailable := toString .Values.config.defaultMinAvailable }}
-  {{- if and (ne $minAvailable "") (ne $minAvailable "null") (ne $minAvailable "<nil>") }}
-  defaultMinAvailable: {{ .Values.config.defaultMinAvailable | quote }}
-  {{- end }}
-  {{- end }}
-  {{- if .Values.config.defaultMaxUnavailable }}
   {{- $maxUnavailable := toString .Values.config.defaultMaxUnavailable }}
-  {{- if and (ne $maxUnavailable "") (ne $maxUnavailable "null") (ne $maxUnavailable "<nil>") }}
+  {{- $minAvailableValid := and (ne $minAvailable "") (ne $minAvailable "null") (ne $minAvailable "<nil>") }}
+  {{- $maxUnavailableValid := and (ne $maxUnavailable "") (ne $maxUnavailable "null") (ne $maxUnavailable "<nil>") }}
+  {{- if $maxUnavailableValid }}
   defaultMaxUnavailable: {{ .Values.config.defaultMaxUnavailable | quote }}
-  {{- end }}
+  {{- else if $minAvailableValid }}
+  defaultMinAvailable: {{ .Values.config.defaultMinAvailable | quote }}
   {{- end }}
   FixPoorPDBs: {{ .Values.config.FixPoorPDBs | quote }}
   logInterval: {{ .Values.config.logInterval | quote }}

--- a/helm/castai-pdb-controller/values.yaml
+++ b/helm/castai-pdb-controller/values.yaml
@@ -34,7 +34,7 @@ config:
   # Default minAvailable for PDBs (use either defaultMinAvailable or defaultMaxUnavailable, not both)
   # Set to null, "", or omit to disable minAvailable mode
   # Examples: "1", "50%", null, ""
-  defaultMinAvailable: null
+  defaultMinAvailable: "1"
   # Default maxUnavailable for PDBs (use either defaultMinAvailable or defaultMaxUnavailable, not both)
   # Set to null, "", or omit to disable maxUnavailable mode
   # Examples: "1", "50%", null, ""


### PR DESCRIPTION
- Set default minAvailable to '1' for automatic PDB creation
- Add smart template logic to ensure only one PDB mode is active
- maxUnavailable takes precedence when explicitly set
- Users no longer need to manually set null values
- Simplify Helm usage with automatic mode switching
- Update documentation to reflect new default behavior