### PR TITLE
fix: add environment configuration to helm-release workflow

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
- Add github-pages environment to deployment job
- Fix missing environment error in GitHub Pages deployment
- Enable automatic chart publishing when tags are pushed