### PR TITLE
fix: change trigger from tags to releases to avoid environment protec…

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,9 +1,8 @@
 name: Helm Chart Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   release:
@@ -27,12 +26,12 @@ jobs:
       - name: Package Helm chart
         run: |
           helm package helm/castai-pdb-controller
-          mv castai-pdb-controller-*.tgz castai-pdb-controller-${{ github.ref_name }}.tgz
+          mv castai-pdb-controller-*.tgz castai-pdb-controller-${{ github.event.release.tag_name }}.tgz
 
       - name: Create Helm repository
         run: |
           mkdir -p helm-repo
-          cp castai-pdb-controller-${{ github.ref_name }}.tgz helm-repo/
+          cp castai-pdb-controller-${{ github.event.release.tag_name }}.tgz helm-repo/
           helm repo index helm-repo --url https://castai.github.io/castai-pdb-controller
 
       - name: Setup Pages


### PR DESCRIPTION
…tion issues

- Change trigger from 'push tags' to 'release published'
- Update variable references to use release tag name
- Avoid github-pages environment protection rules for tag deployments