### PR TITLE
[castai-pdb-controller]: improve Helm release workflow to preserve existing chart versions

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -29,11 +29,31 @@ jobs:
           helm package helm/castai-pdb-controller
           mv castai-pdb-controller-*.tgz castai-pdb-controller-${{ github.ref_name }}.tgz
 
-      - name: Create Helm repository
+      - name: Download existing Helm repository
         run: |
           mkdir -p helm-repo
+          # Download existing index and charts to preserve old versions
+          if curl -f -s https://castai.github.io/castai-pdb-controller/index.yaml -o existing-index.yaml; then
+            echo "Downloaded existing index.yaml"
+            # Extract existing chart URLs and download them
+            grep -o 'https://castai.github.io/castai-pdb-controller/castai-pdb-controller-[^"]*\.tgz' existing-index.yaml | while read url; do
+              filename=$(basename "$url")
+              if curl -f -s "$url" -o "helm-repo/$filename"; then
+                echo "Downloaded existing chart: $filename"
+              else
+                echo "Failed to download: $url"
+              fi
+            done
+          else
+            echo "No existing repository found, starting fresh"
+          fi
+
+      - name: Add new chart to repository
+        run: |
+          # Copy the new chart
           cp castai-pdb-controller-${{ github.ref_name }}.tgz helm-repo/
-          helm repo index helm-repo --url https://castai.github.io/castai-pdb-controller
+          # Update the index, merging with existing entries
+          helm repo index helm-repo --url https://castai.github.io/castai-pdb-controller --merge existing-index.yaml
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
[castai-pdb-controller] Helm Release Workflow Improvements

### What Changed
- **Preserve Existing Versions**: Updated workflow to download and maintain existing chart versions when publishing new ones
- **Backward Compatibility**: Customers can continue using previous chart versions (0.1.x) alongside new versions (0.2.x)
- **Robust Publishing**: Prevents accidental overwrites of existing charts in the Helm repository
