### PR TITLE
chore: default image to castai-hub Artifact Registry; align Makefile

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: castai-pdb-controller
       containers:
       - name: castai-pdb-controller
-        image: castai/castai-pdb-controller:latest
+        image: us-docker.pkg.dev/castai-hub/library/castai-pdb-controller:0.4
 
 
 

--- a/helm/castai-pdb-controller/README.md
+++ b/helm/castai-pdb-controller/README.md
@@ -55,7 +55,7 @@ helm install castai-pdb-controller castai/castai-pdb-controller \
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `replicaCount` | Number of controller replicas | `2` |
-| `image.repository` | Container image repository | `castai/castai-pdb-controller` |
+| `image.repository` | Container image repository | `us-docker.pkg.dev/castai-hub/library/castai-pdb-controller` |
 | `image.tag` | Container image tag | `"0.4"` |
 | `image.pullPolicy` | Container image pull policy | `IfNotPresent` |
 | `nameOverride` | Override the chart name | `""` |

--- a/helm/castai-pdb-controller/values.yaml
+++ b/helm/castai-pdb-controller/values.yaml
@@ -4,9 +4,8 @@ replicaCount: 2
 
 # Container image configuration
 image:
-  # Container image repository
-  repository: castai/castai-pdb-controller
-  # Container image tag
+  # GCP Artifact Registry (castai-hub). Use imagePullSecrets on the pod if required for your cluster.
+  repository: us-docker.pkg.dev/castai-hub/library/castai-pdb-controller
   tag: "0.4"
   # Container image pull policy
   pullPolicy: IfNotPresent

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 # Makefile for building and pushing a multi-arch Docker image using BuildKit
 
-# Variables
-DOCKER_IMAGE_NAME = castai/castai-pdb-controller
+# Variables — align with Helm default (Artifact Registry castai-hub)
+DOCKER_IMAGE_NAME = us-docker.pkg.dev/castai-hub/library/castai-pdb-controller
 DOCKER_IMAGE_TAGS = latest 0.4
 PLATFORMS = linux/amd64,linux/arm64
 
@@ -24,9 +24,9 @@ build:
 		--push \
 		.
 
-# Push the Docker image to Docker Hub (informational only)
+# Push target is informational (build uses --push to Artifact Registry; authenticate with gcloud/docker first)
 push:
-	@$(foreach tag,$(DOCKER_IMAGE_TAGS),echo "Image pushed to Docker Hub: $(DOCKER_IMAGE_NAME):$(tag)";)
+	@$(foreach tag,$(DOCKER_IMAGE_TAGS),echo "Image: $(DOCKER_IMAGE_NAME):$(tag)";)
 
 # Clean up the buildx builder
 clean:


### PR DESCRIPTION
## Summary
Align runtime and build defaults with **`us-docker.pkg.dev/castai-hub/library/castai-pdb-controller:0.4`** (Helm `values.yaml`, Helm README, root `deployment.yaml`, and `makefile` `DOCKER_IMAGE_NAME`).

## Notes
- **`make build`** still uses `docker buildx ... --push`; authenticate to **`us-docker.pkg.dev`** (e.g. `gcloud auth configure-docker us-docker.pkg.dev`) before pushing.
- Chart **`image.tag`** remains **`0.4`**; override for other tags as needed.

## Test
- `helm lint helm/castai-pdb-controller`
- `go test ./...`


Made with [Cursor](https://cursor.com)

---
### Kimchi Summary
### What changed
Migrates container image hosting from Docker Hub to Google Cloud Artifact Registry (`us-docker.pkg.dev/castai-hub/library/castai-pdb-controller`). Updates Kubernetes deployment manifests, Helm chart defaults, and build configuration to reference the new registry and pin the image to version `0.4`.

### Key changes
- `deployment.yaml`: Changed container image from `castai/castai-pdb-controller:latest` to `us-docker.pkg.dev/castai-hub/library/castai-pdb-controller:0.4`
- `helm/castai-pdb-controller/values.yaml`: Updated `image.repository` to the Artifact Registry path and added comment regarding `imagePullSecrets` for authentication
- `helm/castai-pdb-controller/README.md`: Updated documented default value for `image.repository`
- `Makefile`: Updated `DOCKER_IMAGE_NAME` variable to Artifact Registry path and clarified push target comments

### Impact
- Clusters pulling the image must have network access to `us-docker.pkg.dev`; private registries may require configuring `imagePullSecrets` (noted in `values.yaml` comments)
- The static deployment manifest now uses a pinned tag (`0.4`) instead of `latest`, ensuring reproducible deployments