### PR TITLE
feat: PDB unhealthyPodEvictionPolicy (AlwaysAllow / IfHealthyBudget)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ spec:
 |-------------------------------------------------|------------------------------------------------------------------|--------------------|
 | `workloads.cast.ai/pdb-minAvailable`            | Minimum pods that must be available (int or percent, one only)   | `"2"`, `"50%"`     |
 | `workloads.cast.ai/pdb-maxUnavailable`          | Maximum pods that can be unavailable (int or percent, one only)  | `"1"`, `"25%"`     |
+| `workloads.cast.ai/pdb-unhealthyPodEvictionPolicy` | Override PDB `unhealthyPodEvictionPolicy` (Kubernetes 1.26+)   | `AlwaysAllow`, `IfHealthyBudget` |
 | `workloads.cast.ai/bypass-default-pdb`          | Opt out of automatic PDB management                              | `"true"`           |
 
 ---

--- a/cmd/controller_behavior_test.go
+++ b/cmd/controller_behavior_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Regression tests for core PDB controller behavior (values, annotations, exclusions, unhealthy policy resolution).
+
+func TestParsePDBValue(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want *intstr.IntOrString
+	}{
+		{"", nil},
+		{"  ", nil},
+		{"1", &intstr.IntOrString{Type: intstr.Int, IntVal: 1}},
+		{" 2 ", &intstr.IntOrString{Type: intstr.Int, IntVal: 2}},
+		{"50%", &intstr.IntOrString{Type: intstr.String, StrVal: "50%"}},
+		{"100%", &intstr.IntOrString{Type: intstr.String, StrVal: "100%"}},
+	}
+	for _, tc := range cases {
+		got := parsePDBValue(tc.in)
+		if (got == nil) != (tc.want == nil) {
+			t.Fatalf("parsePDBValue(%q) nil mismatch: got %v want %v", tc.in, got, tc.want)
+		}
+		if got != nil && tc.want != nil {
+			if got.Type != tc.want.Type || got.IntVal != tc.want.IntVal || got.StrVal != tc.want.StrVal {
+				t.Fatalf("parsePDBValue(%q) = %#v want %#v", tc.in, got, tc.want)
+			}
+		}
+	}
+	if parsePDBValue("not-a-number") != nil {
+		t.Fatal("invalid int should return nil")
+	}
+}
+
+func TestParseDurationFromConfigMap(t *testing.T) {
+	t.Parallel()
+	def := 5 * time.Minute
+	data := map[string]string{
+		"ok":    "2m",
+		"bad":   "nope",
+		"zero":  "0s",
+		"empty": "",
+	}
+	if d := parseDurationFromConfigMap(data, "ok", def); d != 2*time.Minute {
+		t.Fatalf("ok: got %v", d)
+	}
+	if d := parseDurationFromConfigMap(data, "missing", def); d != def {
+		t.Fatalf("missing: got %v want %v", d, def)
+	}
+	if d := parseDurationFromConfigMap(data, "bad", def); d != def {
+		t.Fatalf("bad: got %v want %v", d, def)
+	}
+	if d := parseDurationFromConfigMap(data, "zero", def); d != def {
+		t.Fatalf("zero: got %v want %v", d, def)
+	}
+	if d := parseDurationFromConfigMap(data, "empty", def); d != def {
+		t.Fatalf("empty: got %v want %v", d, def)
+	}
+}
+
+func TestHasCustomPDBAnnotations(t *testing.T) {
+	t.Parallel()
+	if hasCustomPDBAnnotations(nil) {
+		t.Fatal("nil map")
+	}
+	if hasCustomPDBAnnotations(map[string]string{}) {
+		t.Fatal("empty map")
+	}
+	if !hasCustomPDBAnnotations(map[string]string{annotationMinAvailable: "1"}) {
+		t.Fatal("minAvailable")
+	}
+	if !hasCustomPDBAnnotations(map[string]string{annotationMaxUnavailable: "1"}) {
+		t.Fatal("maxUnavailable")
+	}
+	if !hasCustomPDBAnnotations(map[string]string{annotationUnhealthyPodEvictionPolicy: "AlwaysAllow"}) {
+		t.Fatal("unhealthy policy")
+	}
+	if hasCustomPDBAnnotations(map[string]string{"other": "x"}) {
+		t.Fatal("unrelated key")
+	}
+}
+
+func TestHasBypassAnnotation(t *testing.T) {
+	t.Parallel()
+	if hasBypassAnnotation(nil) || hasBypassAnnotation(map[string]string{}) {
+		t.Fatal("nil/empty")
+	}
+	if hasBypassAnnotation(map[string]string{annotationBypass: "false"}) {
+		t.Fatal("false should not bypass")
+	}
+	if !hasBypassAnnotation(map[string]string{annotationBypass: "true"}) {
+		t.Fatal("true should bypass")
+	}
+	if hasBypassAnnotation(map[string]string{annotationBypass: "TRUE"}) {
+		t.Fatal("only exact lowercase true bypasses")
+	}
+}
+
+func TestIsWorkloadExcluded_namespaceAndNameRegex(t *testing.T) {
+	resetDefaultPDBConfig()
+	t.Cleanup(resetDefaultPDBConfig)
+
+	defaultPDBConfigLock.Lock()
+	defaultPDBConfig.Exclusions = []ExclusionRule{
+		{NamespaceRegex: "^(istio-system|castai-agent)$", NameRegex: "", Labels: map[string]string{}},
+		{NamespaceRegex: "", NameRegex: `.*-temp$`, Labels: map[string]string{}},
+	}
+	defaultPDBConfigLock.Unlock()
+
+	if !isWorkloadExcluded("istio-system", "istiod", map[string]string{"app": "x"}) {
+		t.Fatal("istio-system should match namespace rule")
+	}
+	if !isWorkloadExcluded("castai-agent", "agent", nil) {
+		t.Fatal("castai-agent should match namespace rule")
+	}
+	if isWorkloadExcluded("app-ns", "api", nil) {
+		t.Fatal("app-ns/api should not be excluded")
+	}
+	if !isWorkloadExcluded("app-ns", "api-temp", nil) {
+		t.Fatal("api-temp should match name suffix rule")
+	}
+	if isWorkloadExcluded("app-ns", "api", map[string]string{"env": "prod"}) {
+		t.Fatal("api without -temp should not match name-only rule")
+	}
+}
+
+func TestIsWorkloadExcluded_labelRule(t *testing.T) {
+	resetDefaultPDBConfig()
+	t.Cleanup(resetDefaultPDBConfig)
+
+	defaultPDBConfigLock.Lock()
+	defaultPDBConfig.Exclusions = []ExclusionRule{
+		{
+			NamespaceRegex: "^app$",
+			NameRegex:      "",
+			Labels:         map[string]string{"skip-pdb": "^true$"},
+		},
+	}
+	defaultPDBConfigLock.Unlock()
+
+	if !isWorkloadExcluded("app", "svc", map[string]string{"skip-pdb": "true"}) {
+		t.Fatal("label skip-pdb=true should exclude")
+	}
+	if isWorkloadExcluded("app", "svc", map[string]string{"skip-pdb": "false"}) {
+		t.Fatal("skip-pdb=false should not exclude")
+	}
+	if isWorkloadExcluded("other", "svc", map[string]string{"skip-pdb": "true"}) {
+		t.Fatal("wrong namespace should not match")
+	}
+}
+
+func TestResolveUnhealthyPodEvictionPolicy_defaultsAndAnnotation(t *testing.T) {
+	resetDefaultPDBConfig()
+	t.Cleanup(resetDefaultPDBConfig)
+
+	if p := resolveUnhealthyPodEvictionPolicy(nil); p != nil {
+		t.Fatalf("no default: want nil, got %v", p)
+	}
+
+	aa := policyv1.AlwaysAllow
+	defaultPDBConfigLock.Lock()
+	defaultPDBConfig.UnhealthyPodEvictionPolicy = &aa
+	defaultPDBConfigLock.Unlock()
+
+	if p := resolveUnhealthyPodEvictionPolicy(nil); p == nil || *p != policyv1.AlwaysAllow {
+		t.Fatalf("default AlwaysAllow: got %v", p)
+	}
+
+	ann := map[string]string{annotationUnhealthyPodEvictionPolicy: "IfHealthyBudget"}
+	if p := resolveUnhealthyPodEvictionPolicy(ann); p == nil || *p != policyv1.IfHealthyBudget {
+		t.Fatalf("annotation override: got %v", p)
+	}
+
+	annInvalid := map[string]string{annotationUnhealthyPodEvictionPolicy: "bogus"}
+	if p := resolveUnhealthyPodEvictionPolicy(annInvalid); p == nil || *p != policyv1.AlwaysAllow {
+		t.Fatalf("invalid annotation should fall back to default, got %v", p)
+	}
+}

--- a/cmd/controller_behavior_test.go
+++ b/cmd/controller_behavior_test.go
@@ -37,6 +37,37 @@ func TestParsePDBValue(t *testing.T) {
 	if parsePDBValue("not-a-number") != nil {
 		t.Fatal("invalid int should return nil")
 	}
+	got := parsePDBValue("  25%  ")
+	if got == nil || got.Type != intstr.String || got.StrVal != "25%" {
+		t.Fatalf("trim percent: got %#v", got)
+	}
+}
+
+func TestIsWorkloadExcluded_noRulesNeverExcludes(t *testing.T) {
+	resetDefaultPDBConfig()
+	t.Cleanup(resetDefaultPDBConfig)
+	if isWorkloadExcluded("any", "thing", nil) {
+		t.Fatal("with no exclusion rules, nothing should be excluded")
+	}
+}
+
+func TestIsWorkloadExcluded_nameAndNamespaceBothRequired(t *testing.T) {
+	resetDefaultPDBConfig()
+	t.Cleanup(resetDefaultPDBConfig)
+	defaultPDBConfigLock.Lock()
+	defaultPDBConfig.Exclusions = []ExclusionRule{
+		{NamespaceRegex: "^prod$", NameRegex: "^api$", Labels: map[string]string{}},
+	}
+	defaultPDBConfigLock.Unlock()
+	if !isWorkloadExcluded("prod", "api", nil) {
+		t.Fatal("prod/api should match")
+	}
+	if isWorkloadExcluded("prod", "api-v2", nil) {
+		t.Fatal("prod/api-v2 should not match name regex")
+	}
+	if isWorkloadExcluded("staging", "api", nil) {
+		t.Fatal("staging/api should not match namespace regex")
+	}
 }
 
 func TestParseDurationFromConfigMap(t *testing.T) {
@@ -62,6 +93,14 @@ func TestParseDurationFromConfigMap(t *testing.T) {
 	}
 	if d := parseDurationFromConfigMap(data, "empty", def); d != def {
 		t.Fatalf("empty: got %v want %v", d, def)
+	}
+}
+
+func TestHasCustomPDBAnnotations_unhealthyKeyPresentCountsAsCustom(t *testing.T) {
+	t.Parallel()
+	// Key presence drives reconcile eligibility even if value is empty (caller may fix later).
+	if !hasCustomPDBAnnotations(map[string]string{annotationUnhealthyPodEvictionPolicy: ""}) {
+		t.Fatal("empty unhealthy annotation value should still count as custom PDB annotations")
 	}
 }
 
@@ -181,5 +220,17 @@ func TestResolveUnhealthyPodEvictionPolicy_defaultsAndAnnotation(t *testing.T) {
 	annInvalid := map[string]string{annotationUnhealthyPodEvictionPolicy: "bogus"}
 	if p := resolveUnhealthyPodEvictionPolicy(annInvalid); p == nil || *p != policyv1.AlwaysAllow {
 		t.Fatalf("invalid annotation should fall back to default, got %v", p)
+	}
+
+	// Empty annotation value → invalid parse → fall back to default AlwaysAllow
+	annEmpty := map[string]string{annotationUnhealthyPodEvictionPolicy: ""}
+	if p := resolveUnhealthyPodEvictionPolicy(annEmpty); p == nil || *p != policyv1.AlwaysAllow {
+		t.Fatalf("empty annotation should fall back to default, got %v", p)
+	}
+
+	// Whitespace in annotation value is trimmed by parser
+	annSpaced := map[string]string{annotationUnhealthyPodEvictionPolicy: "  IfHealthyBudget  "}
+	if p := resolveUnhealthyPodEvictionPolicy(annSpaced); p == nil || *p != policyv1.IfHealthyBudget {
+		t.Fatalf("trimmed annotation: got %v", p)
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,16 +32,17 @@ import (
 )
 
 const (
-	configMapNamespace            = "castai-agent"
-	configMapName                 = "castai-pdb-controller-config"
-	annotationMinAvailable        = "workloads.cast.ai/pdb-minAvailable"
-	annotationMaxUnavailable      = "workloads.cast.ai/pdb-maxUnavailable"
-	annotationBypass              = "workloads.cast.ai/bypass-default-pdb"
-	defaultLogInterval            = 15 * time.Minute
-	defaultPDBScanInterval        = 2 * time.Minute
-	defaultGarbageCollectInterval = 2 * time.Minute
-	defaultPDBDumpInterval        = 5 * time.Minute
-	pdbDumpFile                   = "/tmp/castai-pdbs.yaml"
+	configMapNamespace                   = "castai-agent"
+	configMapName                        = "castai-pdb-controller-config"
+	annotationMinAvailable               = "workloads.cast.ai/pdb-minAvailable"
+	annotationMaxUnavailable             = "workloads.cast.ai/pdb-maxUnavailable"
+	annotationUnhealthyPodEvictionPolicy = "workloads.cast.ai/pdb-unhealthyPodEvictionPolicy"
+	annotationBypass                     = "workloads.cast.ai/bypass-default-pdb"
+	defaultLogInterval                   = 15 * time.Minute
+	defaultPDBScanInterval               = 2 * time.Minute
+	defaultGarbageCollectInterval        = 2 * time.Minute
+	defaultPDBDumpInterval               = 5 * time.Minute
+	pdbDumpFile                          = "/tmp/castai-pdbs.yaml"
 	// When no PDB exists yet, re-list a few times to catch concurrent writers without a long fixed sleep (GitHub #10).
 	pdbRaceRecheckAttempts = 8
 	pdbRaceRecheckInterval = 250 * time.Millisecond
@@ -54,14 +55,15 @@ type ExclusionRule struct {
 }
 
 type DefaultPDBConfig struct {
-	MinAvailable           *intstr.IntOrString
-	MaxUnavailable         *intstr.IntOrString
-	FixPoorPDBs            bool
-	LogInterval            time.Duration
-	PDBScanInterval        time.Duration
-	GarbageCollectInterval time.Duration
-	PDBDumpInterval        time.Duration
-	Exclusions             []ExclusionRule
+	MinAvailable               *intstr.IntOrString
+	MaxUnavailable             *intstr.IntOrString
+	UnhealthyPodEvictionPolicy *policyv1.UnhealthyPodEvictionPolicyType
+	FixPoorPDBs                bool
+	LogInterval                time.Duration
+	PDBScanInterval            time.Duration
+	GarbageCollectInterval     time.Duration
+	PDBDumpInterval            time.Duration
+	Exclusions                 []ExclusionRule
 }
 
 var (
@@ -143,6 +145,61 @@ func isWorkloadExcluded(namespace, name string, labels map[string]string) bool {
 	return false
 }
 
+func unhealthyPodEvictionStr(p *policyv1.UnhealthyPodEvictionPolicyType) string {
+	if p == nil {
+		return "<unset>"
+	}
+	return string(*p)
+}
+
+// parseUnhealthyPodEvictionPolicy parses ConfigMap or annotation values for PodDisruptionBudget.spec.unhealthyPodEvictionPolicy (Kubernetes 1.26+).
+// Empty string returns nil (omit field; API default applies). Valid values: IfHealthyBudget, AlwaysAllow (case-insensitive).
+func parseUnhealthyPodEvictionPolicy(s string) *policyv1.UnhealthyPodEvictionPolicyType {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	switch strings.ToLower(s) {
+	case strings.ToLower(string(policyv1.IfHealthyBudget)):
+		p := policyv1.IfHealthyBudget
+		return &p
+	case strings.ToLower(string(policyv1.AlwaysAllow)):
+		p := policyv1.AlwaysAllow
+		return &p
+	default:
+		logWarnf("Invalid unhealthyPodEvictionPolicy %q (valid: IfHealthyBudget, AlwaysAllow); ignoring", s)
+		return nil
+	}
+}
+
+func resolveUnhealthyPodEvictionPolicy(workloadAnnotations map[string]string) *policyv1.UnhealthyPodEvictionPolicyType {
+	if workloadAnnotations != nil {
+		if v, ok := workloadAnnotations[annotationUnhealthyPodEvictionPolicy]; ok {
+			if p := parseUnhealthyPodEvictionPolicy(v); p != nil {
+				return p
+			}
+		}
+	}
+	defaultPDBConfigLock.RLock()
+	def := defaultPDBConfig.UnhealthyPodEvictionPolicy
+	defaultPDBConfigLock.RUnlock()
+	if def == nil {
+		return nil
+	}
+	c := *def
+	return &c
+}
+
+func unhealthyPodEvictionPoliciesEqual(a, b *policyv1.UnhealthyPodEvictionPolicyType) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
 // updateExistingPDB updates an existing castai PDB with new configuration
 func updateExistingPDB(ctx context.Context, clientset *kubernetes.Clientset, existingPDB *policyv1.PodDisruptionBudget, workloadAnnotations map[string]string, replicas *int32, namespace, name string, obj interface{}) {
 	// Parse PDB configuration from annotations or defaults
@@ -183,6 +240,8 @@ func updateExistingPDB(ctx context.Context, clientset *kubernetes.Clientset, exi
 		pdbSpec.MaxUnavailable = maxUnavailable
 	}
 
+	pdbSpec.UnhealthyPodEvictionPolicy = resolveUnhealthyPodEvictionPolicy(workloadAnnotations)
+
 	// Check if update is needed
 	if existingPDB.Spec.MinAvailable == nil && pdbSpec.MinAvailable != nil {
 		needsUpdate = true
@@ -202,6 +261,10 @@ func updateExistingPDB(ctx context.Context, clientset *kubernetes.Clientset, exi
 		if existingPDB.Spec.MaxUnavailable.String() != pdbSpec.MaxUnavailable.String() {
 			needsUpdate = true
 		}
+	}
+
+	if !unhealthyPodEvictionPoliciesEqual(existingPDB.Spec.UnhealthyPodEvictionPolicy, pdbSpec.UnhealthyPodEvictionPolicy) {
+		needsUpdate = true
 	}
 
 	if needsUpdate {
@@ -525,9 +588,15 @@ func updateDefaultPDBConfig(ctx context.Context, cm *corev1.ConfigMap, clientset
 		logDebugf("No exclusions found in ConfigMap")
 	}
 
+	var unhealthyPodEviction *policyv1.UnhealthyPodEvictionPolicyType
+	if val, ok := cm.Data["defaultUnhealthyPodEvictionPolicy"]; ok {
+		unhealthyPodEviction = parseUnhealthyPodEvictionPolicy(val)
+	}
+
 	defaultPDBConfigLock.Lock()
 	defaultPDBConfig.MinAvailable = minAvailable
 	defaultPDBConfig.MaxUnavailable = maxUnavailable
+	defaultPDBConfig.UnhealthyPodEvictionPolicy = unhealthyPodEviction
 	defaultPDBConfig.FixPoorPDBs = fixPoorPDBs
 	defaultPDBConfig.LogInterval = logInterval
 	defaultPDBConfig.PDBScanInterval = pdbScanInterval
@@ -536,9 +605,9 @@ func updateDefaultPDBConfig(ctx context.Context, cm *corev1.ConfigMap, clientset
 	defaultPDBConfig.Exclusions = exclusions
 	defaultPDBConfigLock.Unlock()
 
-	logInfof("Default PDB config updated from ConfigMap: defaultMinAvailable=%v, defaultMaxUnavailable=%v, FixPoorPDBs=%v, "+
+	logInfof("Default PDB config updated from ConfigMap: defaultMinAvailable=%v, defaultMaxUnavailable=%v, defaultUnhealthyPodEvictionPolicy=%v, FixPoorPDBs=%v, "+
 		"logInterval=%v, pdbScanInterval=%v, garbageCollectInterval=%v, pdbDumpInterval=%v, exclusions=%d rules\n",
-		minAvailable, maxUnavailable, fixPoorPDBs, logInterval, pdbScanInterval,
+		minAvailable, maxUnavailable, unhealthyPodEvictionStr(unhealthyPodEviction), fixPoorPDBs, logInterval, pdbScanInterval,
 		garbageCollectInterval, pdbDumpInterval, len(exclusions))
 
 	logDebugf("Final exclusion rules loaded: %d rules", len(exclusions))
@@ -564,6 +633,7 @@ func resetDefaultPDBConfig() {
 	defaultPDBConfig.GarbageCollectInterval = defaultGarbageCollectInterval
 	defaultPDBConfig.PDBDumpInterval = defaultPDBDumpInterval
 	defaultPDBConfig.Exclusions = nil
+	defaultPDBConfig.UnhealthyPodEvictionPolicy = nil
 	defaultPDBConfigLock.Unlock()
 	syncLogLevelFromData(nil)
 	logInfof("Default PDB config reset: using built-in fallback\n")
@@ -1087,6 +1157,8 @@ func createPDBForWorkload(ctx context.Context, clientset *kubernetes.Clientset, 
 		pdbSpec.MaxUnavailable = maxUnavailable
 	}
 
+	pdbSpec.UnhealthyPodEvictionPolicy = resolveUnhealthyPodEvictionPolicy(workloadAnnotations)
+
 	if exists {
 		needsUpdate := false
 		if existingPDB.Spec.MinAvailable == nil && pdbSpec.MinAvailable != nil {
@@ -1103,6 +1175,9 @@ func createPDBForWorkload(ctx context.Context, clientset *kubernetes.Clientset, 
 			needsUpdate = true
 		} else if existingPDB.Spec.MaxUnavailable != nil && pdbSpec.MaxUnavailable != nil &&
 			existingPDB.Spec.MaxUnavailable.String() != pdbSpec.MaxUnavailable.String() {
+			needsUpdate = true
+		}
+		if !unhealthyPodEvictionPoliciesEqual(existingPDB.Spec.UnhealthyPodEvictionPolicy, pdbSpec.UnhealthyPodEvictionPolicy) {
 			needsUpdate = true
 		}
 		if needsUpdate {
@@ -1323,6 +1398,9 @@ func hasCustomPDBAnnotations(annotations map[string]string) bool {
 		return true
 	}
 	if _, ok := annotations[annotationMaxUnavailable]; ok {
+		return true
+	}
+	if _, ok := annotations[annotationUnhealthyPodEvictionPolicy]; ok {
 		return true
 	}
 	return false

--- a/cmd/unhealthy_policy_test.go
+++ b/cmd/unhealthy_policy_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	policyv1 "k8s.io/api/policy/v1"
+)
+
+func TestParseUnhealthyPodEvictionPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want *policyv1.UnhealthyPodEvictionPolicyType
+	}{
+		{"empty", "", nil},
+		{"spaces", "  ", nil},
+		{"AlwaysAllow", "AlwaysAllow", ptrPolicy(policyv1.AlwaysAllow)},
+		{"alwaysallow_lower", "alwaysallow", ptrPolicy(policyv1.AlwaysAllow)},
+		{"IfHealthyBudget", "IfHealthyBudget", ptrPolicy(policyv1.IfHealthyBudget)},
+		{"ifhealthybudget_lower", "ifhealthybudget", ptrPolicy(policyv1.IfHealthyBudget)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseUnhealthyPodEvictionPolicy(tc.in)
+			if !unhealthyPodEvictionPoliciesEqual(got, tc.want) {
+				t.Fatalf("parseUnhealthyPodEvictionPolicy(%q) = %v want %v", tc.in, strPtr(got), strPtr(tc.want))
+			}
+		})
+	}
+	if p := parseUnhealthyPodEvictionPolicy("bogus"); p != nil {
+		t.Fatalf("invalid value should return nil, got %v", *p)
+	}
+}
+
+func ptrPolicy(p policyv1.UnhealthyPodEvictionPolicyType) *policyv1.UnhealthyPodEvictionPolicyType {
+	return &p
+}
+
+func strPtr(p *policyv1.UnhealthyPodEvictionPolicyType) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return string(*p)
+}
+
+func TestUnhealthyPodEvictionPoliciesEqual(t *testing.T) {
+	a := policyv1.AlwaysAllow
+	b := policyv1.IfHealthyBudget
+	if !unhealthyPodEvictionPoliciesEqual(nil, nil) {
+		t.Fatal("nil nil")
+	}
+	if unhealthyPodEvictionPoliciesEqual(&a, nil) {
+		t.Fatal("a nil")
+	}
+	if !unhealthyPodEvictionPoliciesEqual(&a, &a) {
+		t.Fatal("a a")
+	}
+	if unhealthyPodEvictionPoliciesEqual(&a, &b) {
+		t.Fatal("a b")
+	}
+}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: castai-pdb-controller
       containers:
       - name: castai-pdb-controller
-        image: us-docker.pkg.dev/castai-hub/library/castai-pdb-controller:0.4
+        image: us-docker.pkg.dev/castai-hub/library/castai-pdb-controller:0.5
 
 
 

--- a/helm/castai-pdb-controller/Chart.yaml
+++ b/helm/castai-pdb-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-pdb-controller
 description: A Helm chart for CAST AI PDB Controller
 type: application
-version: 0.2.2
-appVersion: "0.4"
+version: 0.2.3
+appVersion: "0.5"
 maintainers:
   - name: CAST AI 

--- a/helm/castai-pdb-controller/README.md
+++ b/helm/castai-pdb-controller/README.md
@@ -56,7 +56,7 @@ helm install castai-pdb-controller castai/castai-pdb-controller \
 |-----------|-------------|---------|
 | `replicaCount` | Number of controller replicas | `2` |
 | `image.repository` | Container image repository | `us-docker.pkg.dev/castai-hub/library/castai-pdb-controller` |
-| `image.tag` | Container image tag | `"0.4"` |
+| `image.tag` | Container image tag | `"0.5"` |
 | `image.pullPolicy` | Container image pull policy | `IfNotPresent` |
 | `nameOverride` | Override the chart name | `""` |
 | `fullnameOverride` | Override the full app name | `""` |
@@ -72,6 +72,7 @@ helm install castai-pdb-controller castai/castai-pdb-controller \
 | `config.garbageCollectInterval` | Garbage collection interval | `"2m"` |
 | `config.pdbDumpInterval` | PDB dump interval | `"5m"` |
 | `config.logLevel` | Application log level: `debug`, `info`, `warn`, `error` | `"info"` |
+| `config.defaultUnhealthyPodEvictionPolicy` | PDB `unhealthyPodEvictionPolicy` default (K8s 1.26+): `IfHealthyBudget`, `AlwaysAllow`, or `""` to omit | `""` |
 | `config.exclusions` | YAML list of exclusion rules for workloads | `[]` (empty) |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `512Mi` |

--- a/helm/castai-pdb-controller/templates/configmap.yaml
+++ b/helm/castai-pdb-controller/templates/configmap.yaml
@@ -21,6 +21,10 @@ data:
   garbageCollectInterval: {{ .Values.config.garbageCollectInterval | quote }}
   pdbDumpInterval: {{ .Values.config.pdbDumpInterval | quote }}
   logLevel: {{ .Values.config.logLevel | quote }}
+  {{- $uep := toString .Values.config.defaultUnhealthyPodEvictionPolicy }}
+  {{- if and $uep (ne $uep "") (ne $uep "null") (ne $uep "<nil>") }}
+  defaultUnhealthyPodEvictionPolicy: {{ .Values.config.defaultUnhealthyPodEvictionPolicy | quote }}
+  {{- end }}
   {{- if .Values.config.exclusions }}
   exclusions: |
 {{ toYaml .Values.config.exclusions | indent 4 }}

--- a/helm/castai-pdb-controller/values.yaml
+++ b/helm/castai-pdb-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 image:
   # GCP Artifact Registry (castai-hub). Use imagePullSecrets on the pod if required for your cluster.
   repository: us-docker.pkg.dev/castai-hub/library/castai-pdb-controller
-  tag: "0.4"
+  tag: "0.5"
   # Container image pull policy
   pullPolicy: IfNotPresent
 
@@ -50,6 +50,8 @@ config:
   pdbDumpInterval: "5m"
   # Application log level: debug, info, warn (or warning), error
   logLevel: "info"
+  # PodDisruptionBudget unhealthyPodEvictionPolicy (Kubernetes 1.26+). IfHealthyBudget | AlwaysAllow | "" (omit)
+  defaultUnhealthyPodEvictionPolicy: ""
   # Exclusion rules for workloads to skip PDB creation
   # Each rule is evaluated independently; if a workload matches ANY rule, no PDB is created
   # Within a single rule, all specified criteria (namespaceRegex, nameRegex, labels) must match (AND logic)

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 
 # Variables — align with Helm default (Artifact Registry castai-hub)
 DOCKER_IMAGE_NAME = us-docker.pkg.dev/castai-hub/library/castai-pdb-controller
-DOCKER_IMAGE_TAGS = latest 0.4
+DOCKER_IMAGE_TAGS = latest 0.5
 PLATFORMS = linux/amd64,linux/arm64
 
 # Enable BuildKit


### PR DESCRIPTION
## Summary
Adds support for **`spec.unhealthyPodEvictionPolicy`** on castai-managed PDBs (Kubernetes **1.26+**), requested for drain scenarios where unhealthy pods should not block eviction when using `minAvailable`.

## Configuration
- **ConfigMap** (`castai-pdb-controller-config`): optional `defaultUnhealthyPodEvictionPolicy` — `AlwaysAllow`, `IfHealthyBudget`, or omit / empty for API default.
- **Workload annotation**: `workloads.cast.ai/pdb-unhealthyPodEvictionPolicy` overrides the default (same valid values).

## Implementation
- Resolve policy in `createPDBForWorkload` and `updateExistingPDB`; compare on PDB updates.
- `hasCustomPDBAnnotations` includes the new annotation key.
- Helm: optional `config.defaultUnhealthyPodEvictionPolicy` in values + ConfigMap template when set.

## Chart / image
- Chart **0.2.3**, **appVersion 0.5**, default image tag **0.5** (publish image to Artifact Registry before relying on default).

## Tests
- `go test ./... -count=1 -race` — unit/regression for parsing, exclusions, annotations, unhealthy policy resolution.

## Post-merge
1. Build and push **`us-docker.pkg.dev/castai-hub/library/castai-pdb-controller:0.5`** (and `latest` if applicable).
2. Tag **`v0.2.3`** (or aligned version) to trigger Helm chart release workflow.


Made with [Cursor](https://cursor.com)

---
### Kimchi Summary
### What changed
Adds support for configuring `unhealthyPodEvictionPolicy` (`AlwaysAllow` or `IfHealthyBudget`) on PodDisruptionBudgets managed by the controller. The policy can be set globally via ConfigMap/Helm values or overridden per-workload using a new annotation.

### Why
Kubernetes 1.26+ introduced `unhealthyPodEvictionPolicy` for PDBs. Users need a way to apply this policy to controller-generated PDBs, both globally and for specific workloads.

### Key changes
- `cmd/main.go`: Added `annotationUnhealthyPodEvictionPolicy`, `parseUnhealthyPodEvictionPolicy`, `resolveUnhealthyPodEvictionPolicy`, and `unhealthyPodEvictionPoliciesEqual`. Integrated policy resolution into `updateExistingPDB`, `createPDBForWorkload`, and `updateDefaultPDBConfig`.
- `cmd/main.go`: Extended `DefaultPDBConfig` with `UnhealthyPodEvictionPolicy` and updated `hasCustomPDBAnnotations` to detect the new annotation.
- `cmd/controller_behavior_test.go`, `cmd/unhealthy_policy_test.go`: Added regression and unit tests for policy parsing, resolution, and reconciliation behavior.
- Helm chart: Added `config.defaultUnhealthyPodEvictionPolicy` to `values.yaml`, `configmap.yaml`, and documented it in the Helm README.
- `README.md`: Documented the `workloads.cast.ai/pdb-unhealthyPodEvictionPolicy` annotation.
- Bumped controller version from `0.4` to `0.5` in deployment manifests, Helm chart, and Makefile.

### Impact
- The `unhealthyPodEvictionPolicy` field is only effective on Kubernetes 1.26+ clusters.
- Existing PDBs without the new configuration remain unchanged; the change is backward-compatible.