### PR TITLE
TOOL-1188: add landing page for Helm chart GitHub Pages

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -102,6 +102,9 @@ jobs:
             helm repo index helm-repo --url https://castai.github.io/castai-pdb-controller
           fi
 
+      - name: Copy index page
+        run: cp helm/index.html helm-repo/index.html
+
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 

--- a/helm/index.html
+++ b/helm/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>CAST AI PDB Controller — Helm Chart</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; max-width: 640px; margin: 60px auto; padding: 0 20px; color: #24292f; }
+    h1 { font-size: 1.5em; }
+    code { background: #f6f8fa; padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto; }
+    pre code { padding: 0; background: none; }
+    a { color: #0969da; }
+  </style>
+</head>
+<body>
+  <h1>CAST AI PDB Controller</h1>
+  <p>Helm chart repository for <a href="https://github.com/castai/castai-pdb-controller">castai-pdb-controller</a>.</p>
+  <h2>Usage</h2>
+  <pre><code>helm repo add castai-pdb-controller https://castai.github.io/castai-pdb-controller
+helm repo update
+helm install castai-pdb-controller castai-pdb-controller/castai-pdb-controller</code></pre>
+  <h2>Available versions</h2>
+  <pre><code>helm search repo castai-pdb-controller --versions</code></pre>
+  <p><a href="index.yaml">index.yaml</a></p>
+</body>
+</html>


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds a static `index.html` landing page to the Helm chart repository and publishes it via GitHub Pages during the release workflow.

### Why
Browsing the chart repository URL previously showed an unhelpful auto-generated directory listing. A dedicated page gives users copy-paste ready `helm` commands and clear navigation to the chart index.

### Key changes
- `helm/index.html`: New landing page with installation instructions, repo styling, and links to `index.yaml` and the GitHub repository.
- `.github/workflows/release-image.yaml`: Added `Copy index page` step that copies `helm/index.html` into `helm-repo/index.html` before deploying to Pages.