### PR TITLE
Add custom label to deployment configuration

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       app: castai-pdb-controller
+      just-some-weird-stuff: here
   template:
     metadata:
       labels:


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Added the label `just-some-weird-stuff: here` to the pod selector in the `castai-pdb-controller` Deployment manifest.

### Key changes
- `deployment.yaml`: Added `just-some-weird-stuff: here` to `spec.selector.matchLabels`.

### Impact
- Modifying `spec.selector` on an existing Deployment is an immutable operation in Kubernetes and may require recreating the resource to apply the change.